### PR TITLE
Modifications for national safe haven

### DIFF
--- a/03_prep.R
+++ b/03_prep.R
@@ -17,7 +17,11 @@ ccp_data = ccp_data %>%
   mutate(dag_id = ifelse(dag_id == 'G405H', 'G450H', dag_id)) %>% 
   select(subjid, dag_id, everything())
 
-areas = read_csv('https://raw.githubusercontent.com/SurgicalInformatics/ccp_location_lookups/master/data_out_ccp_lookups/ccp_dag_id_lookup.csv') %>% 
+# XXX abrooks changed path for safehaven
+if (!safehaven) {
+  ccp_dag_id_lookup_csv = 'https://raw.githubusercontent.com/SurgicalInformatics/ccp_location_lookups/master/data_out_ccp_lookups/ccp_dag_id_lookup.csv'
+}
+areas = read_csv(ccp_dag_id_lookup_csv) %>% 
   as_tibble() %>% 
   rename(postcode_e = postcode,
          redcap_data_access_group_e  = redcap_data_access_group) %>% 

--- a/03_prep.R
+++ b/03_prep.R
@@ -98,6 +98,8 @@ definite_no_subjid = ccp_data %>%
 
 # Since we have multiple projects, it's possible that subjids are no longer unique
 # We will have to drop non-unique subjids or they will be matched with the wrong outcome etc data
+# XXX abrooks wrapped in (!safehaven) because no 'projects' var
+if (!safehaven) {
 duplicates_across_projects = ccp_data %>%
   distinct(subjid, project) %>%
   add_count(subjid) %>%
@@ -109,6 +111,7 @@ ccp_data = ccp_data %>%
 if (nrow(duplicates_across_projects) != 0){
   message(paste(nrow(duplicates_across_projects), "duplicate subjids across projects detected and removed."))
   duplicates_across_projects
+}
 }
 
 # Added 18/08/2021 to deal with follow-up patients having no assigned event and being dropped in next section. 

--- a/03_prep.R
+++ b/03_prep.R
@@ -3,6 +3,7 @@
 # Centre for Medical Informatics, Usher Institute, University of Edinburgh 2020
 
 # Functions require library(tidyverse), requires() nor :: not currently written in.  
+## 2021-11-25 abrooks removed purrr::discard for safehaven batching, fixed age for safehaven
 
 library(tidyverse)
 library(lubridate)
@@ -496,14 +497,16 @@ topline = ccp_data %>%
            redcap_event_name == "Day 1 Hospital&ICU Admission (Arm 2: TIER 1)" |
            redcap_event_name == "Day 1 (Arm 3: TIER 2)") %>% 
   filter(is.na(redcap_repeat_instrument)) %>%
-  purrr::discard(~all(is.na(.))) %>% 
+  #purrr::discard(~all(is.na(.))) %>% 
   ff_relabel_df(ccp_data)
 
 
 # Add IMD ---------------------------------------------------------------------------------------
 ## Get main lookup
+# XXX abrooks safehaven has different location, load data outside this script
+if (!safehaven) {
 postcode_main_lookup = read_csv('https://argonaut.is.ed.ac.uk/public/lookup/NSPL_FEB_2020_UK.csv')
-
+}
 pcode_data = topline %>% 
   select(subjid, postcode) %>% 
   mutate(length_pcode = str_length(postcode),

--- a/03_prep.R
+++ b/03_prep.R
@@ -162,13 +162,13 @@ ccp_data = ccp_data %>%
       !is.na(cestdat) ~ cestdat,    # onset
       !is.na(dsstdat) ~ dsstdat),   # enrolment
     
-    age = (anydat - agedat) %>%
-      as.numeric()/365, # Changed to deal with children, need fractions
-    
+    # XXX abrooks wrapped in (!safehaven) as no 'agedat' var
+    age = ifelse(safehaven, NA_real_, as.numeric(anydat - agedat)/365), # Changed to deal with children, need fractions
+ 
     # Add infants to age variable by making months a fraction of year
     age_estimateyears = as.numeric(age_estimateyears),
     age_estimateyears = ifelse(age_estimateyearsu == "Months", age_estimateyears / 12, age_estimateyears),
-    
+ 
     # DOB missing as no consent in some, therefore use age_estimateyears
     age = case_when(
       is.na(age) & !is.na(calc_age) ~ calc_age,

--- a/04_prep_in_progress.R
+++ b/04_prep_in_progress.R
@@ -115,6 +115,7 @@ outcome = ccp_data %>%
 # Add outcome to topline ---------------------------------------------------------------------------------
 ## If this adds extra rows to topline, it is because there are patient IDs duplicated across tiers in error. 
 if (safehaven) { topline$dsterm <- NULL; } # all-NA cols were not previously removed
+if (safehaven) { topline$dsstdtc <- NULL; } # all-NA cols were not previously removed
 topline = topline %>%
   left_join(outcome %>% select(subjid, dsterm, dsstdtc), by = "subjid") %>%
   mutate(

--- a/04_prep_in_progress.R
+++ b/04_prep_in_progress.R
@@ -11,6 +11,7 @@
 ## Note any daily_ variable comes from daily form and 
 ## _hoterm/_proccur variables from final treatment form. 
 ## These take a minute or two to run as it iterates by patient.
+### 2021-11-25 abrooks removed purrr::discard for safehaven batching
 treatment = ccp_data %>% 
   filter(redcap_repeat_instrument != "Infectious Respiratory Disease Pathogen Testing" | 
            is.na(redcap_repeat_instrument)) %>% 
@@ -107,12 +108,13 @@ outcome = ccp_data %>%
   # Bring in variables from other events like this.
   # remove duplicate variables now also in ccp_data before joining
   select(-c(age, sex)) %>% 
-  left_join(topline %>% select(subjid, age, sex), by = "subjid") %>% 
-  purrr::discard(~all(is.na(.)))
+  left_join(topline %>% select(subjid, age, sex), by = "subjid") #%>% 
+  #purrr::discard(~all(is.na(.)))
 
 
 # Add outcome to topline ---------------------------------------------------------------------------------
 ## If this adds extra rows to topline, it is because there are patient IDs duplicated across tiers in error. 
+if (safehaven) { topline$dsterm <- NULL; } # all-NA cols were not previously removed
 topline = topline %>%
   left_join(outcome %>% select(subjid, dsterm, dsstdtc), by = "subjid") %>%
   mutate(

--- a/05_oneline.R
+++ b/05_oneline.R
@@ -1,6 +1,10 @@
 # Oneline combines Day 1 and Discharge data and includes summary variables  --------------------------------------------------------------------
 ## One line per patient
 ### Note: This filters out a very small number of patients who have no Day 1 or Discharge data entered, but do have data on an "Additional days" form
+#### FOR SAFE HAVEN ONLY
+##### 2021-05-27 abrooks removed PatientID from list of columns to delete
+##### 2021-06-29 abrooks removed purrr::discard (three times)
+##### 2021-11-25 abrooks remove project in case safehaven doesn't have it
 oneline = ccp_data %>%
   # Filter for Day 1 event data
   filter(
@@ -8,7 +12,7 @@ oneline = ccp_data %>%
     redcap_event_name == "Day 1 Hospital&ICU Admission (Arm 2: TIER 1)" |
     redcap_event_name == "Day 1 (Arm 3: TIER 2)") %>%
   filter(is.na(redcap_repeat_instrument)) %>%
-  purrr::discard( ~ all(is.na(.))) %>%
+  #purrr::discard( ~ all(is.na(.))) %>%
   # Join to Discharge event data
   full_join(
     ccp_data %>%
@@ -18,7 +22,7 @@ oneline = ccp_data %>%
         redcap_event_name == "Discharge/Death (Arm 2: TIER 1)" |
         redcap_event_name == "Discharge/Death (Arm 3: TIER 2)") %>%
       filter(is.na(redcap_repeat_instrument)) %>%
-      purrr::discard(~ all(is.na(.))) %>%
+      #purrr::discard(~ all(is.na(.))) %>%
       # Deselect variables to avoid duplicate columns when joining
       select(-c(
           # location data
@@ -27,8 +31,8 @@ oneline = ccp_data %>%
           # summary treatment variables
           any_daily_hoterm:status,
           # other duplicate variables
-          dag_id, redcap_data_access_group, project, arm, arm_n)),
+          dag_id, redcap_data_access_group, arm, arm_n)), # XXX abrooks removed project for safehaven
     by = c("subjid"),
     suffix = (c(".day1", ".disch"))) %>%
-  select(-c(redcap_event_name.day1, redcap_event_name.disch)) %>% 
-  purrr::discard(~all(is.na(.)))
+  select(-c(redcap_event_name.day1, redcap_event_name.disch)) #%>% 
+  #purrr::discard(~all(is.na(.)))


### PR DESCRIPTION
These modifications are required because
* the safe haven has an older version of the table schema
* it runs the cleaning in batches to save memory, which means that it must keep all columns even if they are all-NA so that they can be merged back into a single final table
* some ancillary files are in different location (argosafe is not accessible)

I am not expecting this branch to be merged right away (if at all) because the removal of discard() has not been wrapped in `if (safehaven)` (I couldn't find an easy way to put a conditional into a pipe which didn't break due to R's weird syntax)